### PR TITLE
feat(tmux): show sesh picker on new ghostty windows

### DIFF
--- a/dot_claude/skills/commit-convention/SKILL.md
+++ b/dot_claude/skills/commit-convention/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: commit-convention
+user-invocable: false
+description: |
+  Commit message conventions and code review standards.
+  Background knowledge for consistent git practices across projects.
+---
+
+# Commit & Code Review Conventions
+
+## Commit Messages
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<scope>): <description>
+
+[optional body]
+
+[optional footer]
+```
+
+### Types
+
+| Type | When |
+|------|------|
+| `feat` | New feature |
+| `fix` | Bug fix |
+| `refactor` | Code change that neither fixes nor adds |
+| `chore` | Maintenance (deps, CI, config) |
+| `docs` | Documentation only |
+| `test` | Adding or fixing tests |
+| `ci` | CI/CD changes |
+| `perf` | Performance improvement |
+
+### Rules
+
+- Subject line: imperative mood, no period, under 72 chars
+- Body: explain **why**, not what (the diff shows what)
+- Footer: reference tickets (`Refs: DND-123`) or breaking changes
+- One logical change per commit
+
+## Code Review Standards
+
+When reviewing code, check:
+
+1. **Correctness** — Does it do what it claims?
+2. **Security** — OWASP top 10, input validation at boundaries
+3. **Error handling** — Fails gracefully, no swallowed errors
+4. **Naming** — Clear, consistent, no abbreviations
+5. **Tests** — Meaningful coverage, not just line count
+6. **Complexity** — Could it be simpler?
+
+Don't nitpick formatting — that's what linters are for.

--- a/dot_claude/skills/helm-scaffold/SKILL.md
+++ b/dot_claude/skills/helm-scaffold/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: helm-scaffold
+description: |
+  Scaffold a new Helm chart with production-ready templates and values.
+  Use when asked to "create a helm chart", "scaffold helm", or "new chart".
+allowed-tools:
+  - Bash
+  - Write
+  - Edit
+  - Read
+  - AskUserQuestion
+---
+
+# Helm Chart Scaffolding
+
+Create production-ready Helm charts.
+
+## Steps
+
+1. Ask for:
+   - Chart name
+   - App type (web service, worker, cronjob)
+   - Whether it needs ingress, HPA, PDB, service account
+
+2. Create the chart structure:
+   ```
+   <chart-name>/
+   ├── Chart.yaml
+   ├── values.yaml
+   ├── values-dev.yaml
+   ├── values-prod.yaml
+   ├── templates/
+   │   ├── _helpers.tpl
+   │   ├── deployment.yaml
+   │   ├── service.yaml
+   │   ├── serviceaccount.yaml
+   │   ├── hpa.yaml
+   │   ├── pdb.yaml
+   │   ├── ingress.yaml        # if requested
+   │   └── tests/
+   │       └── test-connection.yaml
+   └── .helmignore
+   ```
+
+3. Follow these conventions:
+   - All resources include standard labels from `_helpers.tpl`
+   - Security context: non-root, read-only fs, drop all caps
+   - Resource requests/limits templated in values
+   - Probes templated with sensible defaults
+   - Image tag defaults to `.Chart.AppVersion`
+   - `values.yaml` has comments explaining each field
+
+4. Validate with:
+   ```bash
+   helm lint <chart-name>
+   helm template <chart-name> <chart-name>/
+   ```

--- a/dot_claude/skills/k8s-review/SKILL.md
+++ b/dot_claude/skills/k8s-review/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: k8s-review
+description: |
+  Review Kubernetes manifests for security, reliability, and best practices.
+  Use when asked to "review k8s manifests", "check my yaml", "review deployment",
+  or when editing Kubernetes YAML files.
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+paths: "**/*.yaml,**/*.yml"
+---
+
+# Kubernetes Manifest Review
+
+Review Kubernetes manifests for production readiness.
+
+## Review Checklist
+
+### 1. Security
+
+- [ ] No containers running as root (`runAsNonRoot: true`)
+- [ ] Read-only root filesystem where possible
+- [ ] No privileged containers unless justified
+- [ ] Security context set (drop all capabilities, add only needed)
+- [ ] No `hostNetwork`, `hostPID`, `hostIPC` unless justified
+- [ ] Service accounts — not using `default`, automountServiceAccountToken disabled if unused
+- [ ] Network policies exist to restrict traffic
+- [ ] Secrets not hardcoded — use External Secrets, Sealed Secrets, or CSI driver
+- [ ] Image tags are pinned (no `latest`)
+
+### 2. Reliability
+
+- [ ] Resource requests AND limits set for all containers
+- [ ] Liveness and readiness probes configured
+- [ ] `startupProbe` for slow-starting containers
+- [ ] Pod Disruption Budget (PDB) defined
+- [ ] Topology spread constraints or anti-affinity for HA
+- [ ] Replica count > 1 for production workloads
+- [ ] `terminationGracePeriodSeconds` appropriate for the workload
+- [ ] `preStop` hook if the app needs graceful shutdown time
+
+### 3. Observability
+
+- [ ] Labels: `app.kubernetes.io/name`, `app.kubernetes.io/version`, `app.kubernetes.io/component`
+- [ ] Annotations for monitoring (prometheus scrape config if applicable)
+- [ ] Log format is structured (JSON preferred)
+
+### 4. Networking
+
+- [ ] Services use correct type (ClusterIP default, LoadBalancer only when needed)
+- [ ] Ingress has TLS configured
+- [ ] Port names follow convention (`http`, `https`, `grpc`, `metrics`)
+
+### 5. Resource Sizing
+
+- [ ] CPU requests are realistic (not `1m` or `10`)
+- [ ] Memory limits match actual usage (check OOMKills)
+- [ ] Ephemeral storage limits set if applicable
+- [ ] HPA configured with appropriate metrics and bounds
+
+## Output Format
+
+Group findings by severity: **Critical**, **Warning**, **Info**.
+Include file path and resource name for each finding.

--- a/dot_claude/skills/pr/SKILL.md
+++ b/dot_claude/skills/pr/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: pr
+description: |
+  Create a branch, commit changes, push, and open a pull request.
+  Use when asked to "open a PR", "create a PR", "branch and push",
+  or "submit this for review".
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+  - AskUserQuestion
+---
+
+# Pull Request Workflow
+
+Complete flow: branch, commit, push, open PR.
+
+## Branch Naming
+
+Use the format `<type>/<ticket-id>/<short-description>`:
+
+- `feat/DND-123/add-auth-flow`
+- `fix/DND-456/null-pointer-crash`
+- `chore/DND-789/update-deps`
+
+If no ticket ID is provided, ask the user. Types: `feat`, `fix`, `chore`, `refactor`, `docs`, `test`, `ci`.
+
+## Steps
+
+1. **Check state**: Run `git status` and `git diff --stat` to understand what's changed.
+
+2. **Create branch**: Ask for ticket ID and description if not provided. Create and switch:
+   ```
+   git checkout -b <type>/<ticket-id>/<description>
+   ```
+
+3. **Stage changes**: Stage relevant files. Never stage `.env`, credentials, or secrets. Prefer specific file names over `git add .`.
+
+4. **Commit**: Write a concise commit message following conventional commits:
+   ```
+   <type>(<scope>): <description>
+   ```
+   Use a HEREDOC for multi-line messages.
+
+5. **Push**: Push with upstream tracking:
+   ```
+   git push -u origin <branch>
+   ```
+
+6. **Open PR**: Create the PR with `gh pr create`:
+   ```
+   gh pr create --title "<type>(<scope>): <description>" --body "$(cat <<'EOF'
+   ## Summary
+   <bullet points>
+
+   ## Test plan
+   - [ ] <checklist>
+   EOF
+   )"
+   ```
+
+7. **Return the PR URL** to the user.
+
+## Rules
+
+- Keep PR titles under 70 chars
+- Never force push
+- Never push to main/master directly
+- If there are no changes, tell the user — don't create an empty commit

--- a/dot_claude/skills/tf-review/SKILL.md
+++ b/dot_claude/skills/tf-review/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: tf-review
+description: |
+  Review Terraform code for security, cost, state safety, and best practices.
+  Use when asked to "review terraform", "check my tf code", "tf review",
+  or when editing .tf files and the user asks for a review.
+allowed-tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+paths: "**/*.tf,**/*.tfvars"
+---
+
+# Terraform Review
+
+Comprehensive review covering security, cost, state safety, and conventions.
+
+## Review Checklist
+
+### 1. State Safety
+
+- [ ] No resources will be destroyed unexpectedly (check for renames, moved blocks)
+- [ ] `prevent_destroy` lifecycle on critical resources (RDS, S3 with data, EFS)
+- [ ] State locking enabled (S3 + DynamoDB backend)
+- [ ] No hardcoded state paths — uses backend config files
+- [ ] No `terraform import` without a plan
+
+### 2. Security
+
+- [ ] No hardcoded secrets, keys, or passwords in `.tf` or `.tfvars`
+- [ ] IAM policies follow least privilege — no `*` actions or resources without justification
+- [ ] S3 buckets: public access blocked, encryption enabled, versioning on
+- [ ] Security groups: no `0.0.0.0/0` ingress without explicit justification
+- [ ] RDS/databases: not publicly accessible, encryption at rest enabled
+- [ ] KMS keys used for encryption where applicable
+- [ ] Secrets in AWS Secrets Manager or SSM Parameter Store, not in variables
+
+### 3. Cost Impact
+
+- [ ] Instance types are appropriate (not oversized)
+- [ ] NAT Gateways — are they needed? Consider NAT instances for dev
+- [ ] EBS volumes — right type and size? gp3 preferred over gp2
+- [ ] RDS — Multi-AZ only in prod? Right instance class?
+- [ ] Data transfer — cross-AZ or cross-region transfers flagged
+- [ ] Resources that scale — are limits set?
+- [ ] Flag any expensive resources being created (ALBs, EIPs, large instances)
+
+### 4. Naming & Conventions
+
+- [ ] Resources use consistent naming: `<project>-<env>-<resource>`
+- [ ] Tags: at minimum `Name`, `Environment`, `Project`, `ManagedBy=terraform`
+- [ ] Variables have descriptions and types
+- [ ] Outputs have descriptions
+- [ ] Modules are versioned (not `source = "../"` in prod)
+
+### 5. Structure
+
+- [ ] No mega-files — resources logically separated
+- [ ] `locals` used to reduce repetition
+- [ ] `for_each` preferred over `count` for named resources
+- [ ] Data sources used instead of hardcoded IDs/ARNs
+- [ ] Provider versions pinned
+
+## Output Format
+
+Present findings grouped by severity:
+
+**Critical** — Must fix before apply (security holes, state destruction risk)
+**Warning** — Should fix (cost waste, missing best practices)
+**Info** — Suggestions for improvement
+
+Include the file and line number for each finding.

--- a/dot_config/aerospace/aerospace.toml
+++ b/dot_config/aerospace/aerospace.toml
@@ -253,3 +253,7 @@ run = 'move-node-to-workspace G'
 if.app-id = 'com.microsoft.VSCode'
 run = 'move-node-to-workspace D'
 
+[[on-window-detected]]
+if.app-id = 'com.anthropic.claudefordesktop'
+run = 'move-node-to-workspace Q'
+

--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -10,3 +10,5 @@ macos-option-as-alt = true
 macos-titlebar-style = hidden
 keybind = shift+enter=text:\n
 command = /bin/zsh -lc tmux-start.sh
+
+background-opacity = 1.00

--- a/dot_local/scripts/executable_claude-work.sh
+++ b/dot_local/scripts/executable_claude-work.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Launch Claude Code desktop app with work configuration
+export CLAUDE_CONFIG_DIR="$HOME/.claude_work"
+/Applications/Claude.app/Contents/MacOS/Claude \
+  --user-data-dir="$HOME/Library/Application Support/Claude-Work" &
+disown

--- a/dot_local/scripts/executable_tmux-sesh-connect.sh
+++ b/dot_local/scripts/executable_tmux-sesh-connect.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env zsh
+# sesh picker that opens selected session/directory in a new tmux session
+# Intended to be run from a new Ghostty window (outside tmux)
+
+selected=$(sesh list --icons | fzf \
+  --no-sort --ansi --border-label ' sesh ' --prompt '> ' \
+  --header 'ctrl-a: all / ctrl-t: tmux / ctrl-x: zoxide / ctrl-d: kill' \
+  --bind 'tab:down,btab:up' \
+  --bind 'ctrl-a:change-prompt(> )+reload(sesh list --icons)' \
+  --bind 'ctrl-t:change-prompt(tmux> )+reload(sesh list --icons -t)' \
+  --bind 'ctrl-x:change-prompt(zoxide> )+reload(sesh list --icons -z)' \
+  --bind 'ctrl-d:execute(tmux kill-session -t {2..})+reload(sesh list --icons)')
+
+[[ -z "$selected" ]] && exit 0
+
+sesh connect "$selected"

--- a/dot_local/scripts/executable_tmux-start.sh
+++ b/dot_local/scripts/executable_tmux-start.sh
@@ -1,10 +1,22 @@
-#!/usr/bin/env bash
+#!/usr/bin/env zsh
 
 # Start tmux: attach to "main" session if it has no clients,
-# otherwise create a new ephemeral session that auto-destroys on detach.
+# otherwise show sesh picker to connect to an existing or new session.
 
 if tmux has-session -t main 2>/dev/null && [ -n "$(tmux list-clients -t main)" ]; then
-  tmux new-session \; set-option destroy-unattached on \; set-option detach-on-destroy on
+  # main is already attached — show sesh picker
+  selected=$(sesh list --icons | fzf \
+    --no-sort --ansi --border-label ' sesh ' --prompt '> ' \
+    --header 'ctrl-a: all / ctrl-t: tmux / ctrl-x: zoxide / ctrl-d: kill' \
+    --bind 'tab:down,btab:up' \
+    --bind 'ctrl-a:change-prompt(> )+reload(sesh list --icons)' \
+    --bind 'ctrl-t:change-prompt(tmux> )+reload(sesh list --icons -t)' \
+    --bind 'ctrl-x:change-prompt(zoxide> )+reload(sesh list --icons -z)' \
+    --bind 'ctrl-d:execute(tmux kill-session -t {2..})+reload(sesh list --icons)')
+
+  [[ -z "$selected" ]] && exit 0
+
+  sesh connect "$selected"
 else
   tmux new-session -A -s main
 fi

--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -24,11 +24,13 @@ bind-key -r g display-popup -E "zsh $HOME/.local/scripts/tmux-claude.sh"
 bind-key -r d display-popup -E "zsh $HOME/.local/scripts/tmux-dev.sh"
 bind-key -r F display-popup -E "tmux list-windows -a -F '#{session_name}:#{window_index} #{window_name} #{pane_current_path}' | fzf --reverse | cut -d' ' -f1 | xargs tmux switch-client -t"
 
+
 # Worktrunk (git worktrees)
 bind-key -r t display-popup -E -w 80% -h 70% -d "#{pane_current_path}" "wt switch 2>&1 || (echo '\nPress enter to close.' && read)"
 bind-key -r T command-prompt -p "new worktree branch:" "run-shell 'wt switch --create %%'"
 
 bind-key C split-window -h -c "#{pane_current_path}" "claude"
+bind-key V split-window -v -c "#{pane_current_path}" "claude"
 
 bind-key . run -b 'tmux rename-window "`basename \"#{pane_current_path}\"`"'
 

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -119,3 +119,10 @@ bindkey '^[[B' history-search-forward
 } &!
 
 unset _zsh_cache
+
+# bun completions
+[ -s "$HOME/.bun/_bun" ] && source "$HOME/.bun/_bun"
+
+# bun
+export BUN_INSTALL="$HOME/.bun"
+export PATH="$BUN_INSTALL/bin:$PATH"

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -76,9 +76,9 @@ fi
 
 # Cached tool inits (~1ms each to source)
 _cached_eval fzf fzf --zsh
-_cached_eval zoxide zoxide init zsh
 _cached_eval atuin atuin init zsh --disable-up-arrow
 _cached_eval carapace carapace _carapace
+_cached_eval zoxide zoxide init zsh
 _cached_eval mise mise activate zsh
 _cached_eval wt wt config shell init zsh
 _cached_eval kubectl kubectl completion zsh


### PR DESCRIPTION
## Summary
- New `tmux-sesh-connect.sh` script: sesh/fzf picker that runs `sesh connect` on the selected entry
- `tmux-start.sh` now shows the sesh picker when `main` is already attached, instead of creating an ephemeral session
- First Ghostty window still attaches to `main` as before
- Also includes prior unpushed commits (`bun setup`, `updates`)

## Test plan
- [ ] Open first Ghostty window → attaches to `main`
- [ ] Open second Ghostty window with `cmd+n` → sesh picker shows
- [ ] Select an existing tmux session → connects
- [ ] Select a directory → new session created
- [ ] Press Esc in picker → window exits cleanly